### PR TITLE
chore: promote tf-spring-demo to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-production/tf-spring-demo-jx-tf-spring-demo/jx-tf-spring-demo-tf-spring-demo-deploy.yaml
+++ b/config-root/namespaces/jx-production/tf-spring-demo-jx-tf-spring-demo/jx-tf-spring-demo-tf-spring-demo-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-tf-spring-demo-tf-spring-demo
   labels:
     draft: draft-app
-    chart: "tf-spring-demo-0.0.1"
+    chart: "tf-spring-demo-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-tf-spring-demo'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx-tf-spring-demo-tf-spring-demo
       containers:
         - name: tf-spring-demo
-          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/tf-spring-demo:0.0.1"
+          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/tf-spring-demo:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-production/tf-spring-demo-jx-tf-spring-demo/tf-spring-demo-svc.yaml
+++ b/config-root/namespaces/jx-production/tf-spring-demo-jx-tf-spring-demo/tf-spring-demo-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: tf-spring-demo
   labels:
-    chart: "tf-spring-demo-0.0.1"
+    chart: "tf-spring-demo-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-tf-spring-demo'

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: 'bb1357b312207e8aae52f55a60cd5439a6752234'
+        git.jenkins-x.io/sha: 'b210188788c8e657c8c05b7dab64952bbcf6fbaa'
         jenkins-x.io/hash: 'ac52067e4a7d4825399c0f807380ca4fc0a7b6e56e8d2046e0d0d1e1fb0238f7'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: 'c77b0f09b55ba548eb3576d802975ff55339d052'
+        git.jenkins-x.io/sha: 'bb1357b312207e8aae52f55a60cd5439a6752234'
         jenkins-x.io/hash: 'ac52067e4a7d4825399c0f807380ca4fc0a7b6e56e8d2046e0d0d1e1fb0238f7'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,7 +100,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> tf-spring-demo </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td><a href='http://tf-spring-demo-jx-production.65.2.47.12.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -210,20 +210,20 @@
   path: helmfiles/jx-production/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     applicationUrl: http://tf-spring-demo-jx-production.65.2.47.12.nip.io
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-05-17T17:53:38Z"
+    firstDeployed: "2021-05-17T18:05:50Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: tf-spring-demo
       url: http://tf-spring-demo-jx-production.65.2.47.12.nip.io
-    lastDeployed: "2021-05-17T17:53:38Z"
+    lastDeployed: "2021-05-17T18:05:50Z"
     name: tf-spring-demo
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
     resourcePath: config-root/namespaces/jx-production/tf-spring-demo-jx-tf-spring-demo
-    version: 0.0.1
+    version: 0.0.2
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.65.2.47.12.nip.io/
 releases:
 - chart: dev/tf-spring-demo
-  version: 0.0.1
+  version: 0.0.2
   name: jx-tf-spring-demo
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote tf-spring-demo to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
