### PR TITLE
chore: promote demo to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/demo-jx-demo/demo-ingress.yaml
+++ b/config-root/namespaces/jx-staging/demo-jx-demo/demo-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: demo/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx-demo'
+  name: demo
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: demo
+              servicePort: 80
+      host: demo-jx-staging.65.2.47.12.nip.io

--- a/config-root/namespaces/jx-staging/demo-jx-demo/demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/demo-jx-demo/demo-svc.yaml
@@ -1,0 +1,20 @@
+# Source: demo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+  labels:
+    chart: "demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx-demo-demo

--- a/config-root/namespaces/jx-staging/demo-jx-demo/jx-demo-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/demo-jx-demo/jx-demo-demo-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: demo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx-demo-demo
+  labels:
+    draft: draft-app
+    chart: "demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jx-demo-demo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx-demo-demo
+    spec:
+      serviceAccountName: jx-demo-demo
+      containers:
+        - name: demo
+          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/demo:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/demo-jx-demo/jx-demo-demo-sa.yaml
+++ b/config-root/namespaces/jx-staging/demo-jx-demo/jx-demo-demo-sa.yaml
@@ -1,0 +1,10 @@
+# Source: demo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx-demo-demo
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: '4ec89f44e0b4b0cb2dd530462101bffab7b491db'
+        git.jenkins-x.io/sha: '35591ff819deadc0db83cd331e6adb4d1fb35699'
         jenkins-x.io/hash: '82af21d9cb8ca7bf7935cc8ae1836ce0ab1080692120ee955a6b69054ad0f9c5'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,12 @@
 	      <td><a href='http://tf-spring-demo-jx-staging.65.2.47.12.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> demo </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://demo-jx-staging.65.2.47.12.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -242,3 +242,18 @@
     repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
     resourcePath: config-root/namespaces/jx-staging/tf-spring-demo-jx-tf-spring-demo
     version: 0.0.2
+  - apiVersion: v1
+    appVersion: 0.0.1
+    applicationUrl: http://demo-jx-staging.65.2.47.12.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-05-17T18:22:30Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: demo
+      url: http://demo-jx-staging.65.2.47.12.nip.io
+    lastDeployed: "2021-05-17T18:22:30Z"
+    name: demo
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
+    resourcePath: config-root/namespaces/jx-staging/demo-jx-demo
+    version: 0.0.1

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/demo
   version: 0.0.1
   name: jx-demo
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: jx-tf-spring-demo
   values:
   - jx-values.yaml
+- chart: dev/demo
+  version: 0.0.1
+  name: jx-demo
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote demo to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
