### PR TITLE
chore: promote demo to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/demo-jx-demo/demo-ingress.yaml
+++ b/config-root/namespaces/jx-production/demo-jx-demo/demo-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: demo/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx-demo'
+  name: demo
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: demo
+              servicePort: 80
+      host: demo-jx-production.65.2.47.12.nip.io

--- a/config-root/namespaces/jx-production/demo-jx-demo/demo-svc.yaml
+++ b/config-root/namespaces/jx-production/demo-jx-demo/demo-svc.yaml
@@ -1,0 +1,20 @@
+# Source: demo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+  labels:
+    chart: "demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx-demo-demo

--- a/config-root/namespaces/jx-production/demo-jx-demo/jx-demo-demo-deploy.yaml
+++ b/config-root/namespaces/jx-production/demo-jx-demo/jx-demo-demo-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: demo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx-demo-demo
+  labels:
+    draft: draft-app
+    chart: "demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: jx-demo-demo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx-demo-demo
+    spec:
+      serviceAccountName: jx-demo-demo
+      containers:
+        - name: demo
+          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/demo:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/demo-jx-demo/jx-demo-demo-sa.yaml
+++ b/config-root/namespaces/jx-production/demo-jx-demo/jx-demo-demo-sa.yaml
@@ -1,0 +1,10 @@
+# Source: demo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx-demo-demo
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: '4ec89f44e0b4b0cb2dd530462101bffab7b491db'
+        git.jenkins-x.io/sha: 'abc00d6318ff9d534d616f7a9d72d45847a9e47f'
         jenkins-x.io/hash: '82af21d9cb8ca7bf7935cc8ae1836ce0ab1080692120ee955a6b69054ad0f9c5'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,8 +25,8 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: '71086ed5c60dc9df0462c9ccf673e255c3545b3d'
-        jenkins-x.io/hash: '82af21d9cb8ca7bf7935cc8ae1836ce0ab1080692120ee955a6b69054ad0f9c5'
+        git.jenkins-x.io/sha: '17f77190014a8782b391197e7623645acf4707be'
+        jenkins-x.io/hash: '1dd1c2b48921540bb77258d70ac34fe487b8ba3c1a35cc914c7e692a976da3bd'
     spec:
       serviceAccountName: lighthouse-webhooks
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: 'abc00d6318ff9d534d616f7a9d72d45847a9e47f'
+        git.jenkins-x.io/sha: '71086ed5c60dc9df0462c9ccf673e255c3545b3d'
         jenkins-x.io/hash: '82af21d9cb8ca7bf7935cc8ae1836ce0ab1080692120ee955a6b69054ad0f9c5'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> demo </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://demo-jx-production.65.2.47.12.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -224,6 +224,21 @@
     repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
     resourcePath: config-root/namespaces/jx-production/tf-spring-demo-jx-tf-spring-demo
     version: 0.0.2
+  - apiVersion: v1
+    appVersion: 0.0.1
+    applicationUrl: http://demo-jx-production.65.2.47.12.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-05-17T18:22:27Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: demo
+      url: http://demo-jx-production.65.2.47.12.nip.io
+    lastDeployed: "2021-05-17T18:22:27Z"
+    name: demo
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
+    resourcePath: config-root/namespaces/jx-production/demo-jx-demo
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/demo
   version: 0.0.1
   name: jx-demo
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: jx-tf-spring-demo
   values:
   - jx-values.yaml
+- chart: dev/demo
+  version: 0.0.1
+  name: jx-demo
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote demo to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
