### PR TITLE
chore: promote demo-python to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/demo-python-jx-demo-python/demo-python-ingress.yaml
+++ b/config-root/namespaces/jx-staging/demo-python-jx-demo-python/demo-python-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: demo-python/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx-demo-python'
+  name: demo-python
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: demo-python
+              servicePort: 80
+      host: demo-python-jx-staging.65.2.47.12.nip.io

--- a/config-root/namespaces/jx-staging/demo-python-jx-demo-python/demo-python-svc.yaml
+++ b/config-root/namespaces/jx-staging/demo-python-jx-demo-python/demo-python-svc.yaml
@@ -1,0 +1,20 @@
+# Source: demo-python/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-python
+  labels:
+    chart: "demo-python-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo-python'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx-demo-python-demo-python

--- a/config-root/namespaces/jx-staging/demo-python-jx-demo-python/jx-demo-python-demo-python-deploy.yaml
+++ b/config-root/namespaces/jx-staging/demo-python-jx-demo-python/jx-demo-python-demo-python-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: demo-python/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx-demo-python-demo-python
+  labels:
+    draft: draft-app
+    chart: "demo-python-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo-python'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jx-demo-python-demo-python
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx-demo-python-demo-python
+    spec:
+      serviceAccountName: jx-demo-python-demo-python
+      containers:
+        - name: demo-python
+          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/demo-python:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/demo-python-jx-demo-python/jx-demo-python-demo-python-sa.yaml
+++ b/config-root/namespaces/jx-staging/demo-python-jx-demo-python/jx-demo-python-demo-python-sa.yaml
@@ -1,0 +1,10 @@
+# Source: demo-python/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx-demo-python-demo-python
+  annotations:
+    meta.helm.sh/release-name: 'jx-demo-python'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: '00c37077a7d0f3e240cec834cf9a974a64967f88'
+        git.jenkins-x.io/sha: '4a49fa054764ba93ad7ca804efe646fd1997c316'
         jenkins-x.io/hash: '1dd1c2b48921540bb77258d70ac34fe487b8ba3c1a35cc914c7e692a976da3bd'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,12 @@
 	      <td><a href='http://demo-jx-staging.65.2.47.12.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> demo-python </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://demo-python-jx-staging.65.2.47.12.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -257,3 +257,18 @@
     repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
     resourcePath: config-root/namespaces/jx-staging/demo-jx-demo
     version: 0.0.1
+  - apiVersion: v1
+    appVersion: 0.0.1
+    applicationUrl: http://demo-python-jx-staging.65.2.47.12.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-05-17T18:40:27Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: demo-python
+      url: http://demo-python-jx-staging.65.2.47.12.nip.io
+    lastDeployed: "2021-05-17T18:40:27Z"
+    name: demo-python
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
+    resourcePath: config-root/namespaces/jx-staging/demo-python-jx-demo-python
+    version: 0.0.1

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,8 @@ releases:
   name: jx-demo
   values:
   - jx-values.yaml
+- chart: dev/demo-python
+  version: 0.0.1
+  name: jx-demo-python
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,5 +21,7 @@ releases:
 - chart: dev/demo-python
   version: 0.0.1
   name: jx-demo-python
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote demo-python to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
