### PR TITLE
chore: promote tf-spring-demo to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/tf-spring-demo-jx-tf-spring-demo/jx-tf-spring-demo-tf-spring-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/tf-spring-demo-jx-tf-spring-demo/jx-tf-spring-demo-tf-spring-demo-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-tf-spring-demo-tf-spring-demo
   labels:
     draft: draft-app
-    chart: "tf-spring-demo-0.0.2"
+    chart: "tf-spring-demo-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-tf-spring-demo'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx-tf-spring-demo-tf-spring-demo
       containers:
         - name: tf-spring-demo
-          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/tf-spring-demo:0.0.2"
+          image: "890324431850.dkr.ecr.ap-south-1.amazonaws.com/data-platform-skn/tf-spring-demo:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/tf-spring-demo-jx-tf-spring-demo/tf-spring-demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/tf-spring-demo-jx-tf-spring-demo/tf-spring-demo-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: tf-spring-demo
   labels:
-    chart: "tf-spring-demo-0.0.2"
+    chart: "tf-spring-demo-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx-tf-spring-demo'

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        git.jenkins-x.io/sha: '5db82657777867754a271591840f6fd52a55ffa6'
+        git.jenkins-x.io/sha: '7dfb41d02554c15a0c436438247757b5d82f62c0'
         jenkins-x.io/hash: 'a4e40a21189efdf8629ce831c7513d1db123bac664531bb8fa99d68f176ba9c4'
     spec:
       serviceAccountName: lighthouse-webhooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> tf-spring-demo </a></td>
-	      <td>0.0.2</td>
+	      <td>0.0.3</td>
 	      <td><a href='http://tf-spring-demo-jx-staging.65.2.47.12.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -258,20 +258,20 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.2
+    appVersion: 0.0.3
     applicationUrl: http://tf-spring-demo-jx-staging.65.2.47.12.nip.io
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-05-17T18:05:37Z"
+    firstDeployed: "2021-05-18T05:19:12Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: tf-spring-demo
       url: http://tf-spring-demo-jx-staging.65.2.47.12.nip.io
-    lastDeployed: "2021-05-17T18:05:37Z"
+    lastDeployed: "2021-05-18T05:19:12Z"
     name: tf-spring-demo
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.65.2.47.12.nip.io/
     resourcePath: config-root/namespaces/jx-staging/tf-spring-demo-jx-tf-spring-demo
-    version: 0.0.2
+    version: 0.0.3
   - apiVersion: v1
     appVersion: 0.0.1
     applicationUrl: http://demo-jx-staging.65.2.47.12.nip.io

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.65.2.47.12.nip.io/
 releases:
 - chart: dev/tf-spring-demo
-  version: 0.0.2
+  version: 0.0.3
   name: jx-tf-spring-demo
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote tf-spring-demo to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
